### PR TITLE
adds an executable

### DIFF
--- a/ascii-tree.js
+++ b/ascii-tree.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var freetree = require('freetree');
 var c0 = String.fromCharCode(9500);
 var c1 = String.fromCharCode(9472);
@@ -44,4 +46,22 @@ function _generate(tree, end, levels) {
     return result;
 }
 
+function read() {
+    var lines = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('readable', function() {
+        var chunk = process.stdin.read();
+        if (chunk !== null) {
+            lines += chunk;
+        }
+    })
+        .on('end', function() {
+            process.stdout.write(generate(lines.trim()));
+        })
+}
+
 exports.generate = generate;
+
+if (require.main === module) {
+    read();
+}

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   },
   "devDependencies": {
     "mocha": "*"
+  },
+  "bin": {
+    "ascii-tree": "ascii-tree.js"
   }
 }


### PR DESCRIPTION
example:

``` shell
$ echo "
#root node
##node1
###node1
##node2
" | ascii-tree
```

Result:

```
root node
├─ node1
│  └─ node1
└─ node2
```
