### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var asciitree = require('ascii-tree');
 var input = '*root node\r\n**node1\r\n***\r\nnode1\r\n**node2';
 var tree = asciitree.generate(str);
 ```
-The line break charachters `\r\n` are required. 
+The line break characters `\r\n` are required. 
 
 ## Generate from an input file
 First prepare an input file using bullets representating a tree


### PR DESCRIPTION
@liushuping, I've corrected a typographical error in the documentation of the [ascii-tree](https://github.com/liushuping/ascii-tree) project. Specifically, I've changed charachter to character. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
